### PR TITLE
Fix logger re-initialisation

### DIFF
--- a/python_common_logger/src/logger.py
+++ b/python_common_logger/src/logger.py
@@ -40,6 +40,10 @@ def initialise_console_logger(logger_name, service_name, level=logging.WARNING, 
         Logger: Initialised logger
     """
     logger = logging.getLogger(logger_name)
+
+    # Skip if already initialised. Helps preventing re-initialisation as Lambda instances share the logger instance.
+    if hasattr(logger, 'initialized'):
+        return logger
     
     # Create handlers
     log_handler = logging.StreamHandler(sys.stdout)
@@ -75,5 +79,8 @@ def initialise_console_logger(logger_name, service_name, level=logging.WARNING, 
     logger.addHandler(log_handler)
 
     logger.setLevel(level)
+
+    logger.propagate = False
+    setattr(logger, 'initialized', True)
     
     return logger


### PR DESCRIPTION
## Jira:

[SEN-6331](https://simpplr.atlassian.net/browse/SEN-6331)

## Description:

* Lambda shares logger instances causing re-initialisation. Prevent if already initialised.
* Disable propagation to parent logger to disable printing twice.

## Type of change:

## Checklist (put x in bracket to check):

Please do not delete options here.
- [x] I have performed a self-review of my code
- [x] Existing unit tests pass locally with my changes
- [ ] I have written coverage for new code
- [ ] I have updated the [Production deployment](https://docs.google.com/spreadsheets/d/1_tc_7h3yPxScUb2JvZyxG0qx8Dl36bP7Fh-86_0kI1A) sheet if this service required production changes in this sprint


[SEN-6331]: https://simpplr.atlassian.net/browse/SEN-6331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ